### PR TITLE
Issue #29 Update Swift-crypto dependency to 2.0.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "a8911e0fadc25aef1071d582355bd1037a176060",
-          "version": "2.0.4"
+          "revision": "067254c79435de759aeef4a6a03e43d087d61312",
+          "version": "2.0.5"
         }
       }
     ]


### PR DESCRIPTION
Update this dependency since it has updates in BoringSSL 
Closes: #29 
ref: https://github.com/apple/swift-crypto/commit/067254c79435de759aeef4a6a03e43d087d61312
