### PR TITLE
Release v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.3
+- Issue #29: update swift-crypto to 2.0.5
+- Make language enum codable so it can be persisted if needed 
 # 2.2.2
 - make all variables MnemonicInteractor public 
 


### PR DESCRIPTION
See changelog.md


`swift test` output
````
Test Suite 'MnemonicSwiftTests' passed at 2022-03-23 11:18:12.972.
	 Executed 24 tests, with 0 failures (0 unexpected) in 0.235 (0.237) seconds
Test Suite 'MnemonicSwiftPackageTests.xctest' passed at 2022-03-23 11:18:12.972.
	 Executed 24 tests, with 0 failures (0 unexpected) in 0.235 (0.237) seconds
Test Suite 'All tests' passed at 2022-03-23 11:18:12.972.
	 Executed 24 tests, with 0 failures (0 unexpected) in 0.235 (0.239) seconds
 ````
 
 
 `pod lib lint` output
 
 ````
 -> MnemonicSwift (2.2.3)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Build preparation complete
    - NOTE  | xcodebuild:  note: Planning
    - NOTE  | xcodebuild:  note: Building targets in dependency order
    - NOTE  | xcodebuild:  note: Using codesigning identity override: 
    - NOTE  | [OSX] xcodebuild:  ld: warning: dylib (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/XCTest) was built for newer macOS version (11.0) than being linked (10.15)
    - NOTE  | [OSX] xcodebuild:  ld: warning: dylib (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib) was built for newer macOS version (11.0) than being linked (10.15)

MnemonicSwift passed validation.
````
