### PR TITLE
MnemonicLanguageType words publicly available

### DIFF
--- a/MnemonicSwift/Mnemonic.swift
+++ b/MnemonicSwift/Mnemonic.swift
@@ -14,7 +14,7 @@ public enum MnemonicLanguageType: Codable, Equatable {
     case english
     case chinese
 
-    func words() -> [String] {
+    public func words() -> [String] {
         switch self {
         case .english:
             return String.englishMnemonics


### PR DESCRIPTION
- The words for the MnemonicLanguageType are now open for anyone to use for any use case, typical one is for suggestions when typing the seed words